### PR TITLE
Docs: fix readme headers to show @putout/plugin instead of putout-plugin

### DIFF
--- a/codemods/apply-replace-all/README.md
+++ b/codemods/apply-replace-all/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-apply-replace-all [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-apply-replace-all [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-apply-replace-all.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-apply-replace-all "npm"

--- a/codemods/convert-emitter-to-promise/README.md
+++ b/codemods/convert-emitter-to-promise/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-emitter-to-promise [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-emitter-to-promise [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [DependencyStatusURL]:      https://david-dm.org/coderaiser/putout?path=codemods/convert-emitter-to-promise
 [DependencyStatusIMGURL]:   https://david-dm.org/coderaiser/putout.svg?path=codemods/convert-emitter-to-promise

--- a/codemods/convert-fs-to-promises/README.md
+++ b/codemods/convert-fs-to-promises/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-fs-to-promises [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-fs-to-promises [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-fs-to-promises.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-fs-to-promises "npm"

--- a/codemods/convert-pascal-to-camel/README.md
+++ b/codemods/convert-pascal-to-camel/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-pascal-to-camel [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-pascal-to-camel [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [DependencyStatusURL]:      https://david-dm.org/coderaiser/putout?path=codemods/convert-pascal-to-camel
 [DependencyStatusIMGURL]:   https://david-dm.org/coderaiser/putout.svg?path=codemods/convert-pascal-to-camel

--- a/codemods/convert-tape-to-supertape/README.md
+++ b/codemods/convert-tape-to-supertape/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-tape-to-supertape  [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-tape-to-supertape  [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [DependencyStatusURL]:      https://david-dm.org/coderaiser/putout?path=packages/plugin-convert-tape-to-supertape
 [DependencyStatusIMGURL]:   https://david-dm.org/coderaiser/putout.svg?path=packages/plugin-convert-tape-to-supertape

--- a/codemods/cut-legacy/README.md
+++ b/codemods/cut-legacy/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-cut-legacy [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-cut-legacy [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [DependencyStatusURL]:      https://david-dm.org/coderaiser/putout?path=codemods/cut-legacy
 [DependencyStatusIMGURL]:   https://david-dm.org/coderaiser/putout.svg?path=codemods/cut-legacy

--- a/codemods/cut-useless-functions/README.md
+++ b/codemods/cut-useless-functions/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-functions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-functions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-functions.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-functions "npm"

--- a/packages/plugin-add-return-await/README.md
+++ b/packages/plugin-add-return-await/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-add-return-await [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-add-return-await [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-add-return-await.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-add-return-await"npm"

--- a/packages/plugin-apply-destructuring/README.md
+++ b/packages/plugin-apply-destructuring/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-apply-destructuring [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-apply-destructuring [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-apply-destructuring.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-apply-destructuring"npm"
 

--- a/packages/plugin-apply-nullish-coalescing/README.md
+++ b/packages/plugin-apply-nullish-coalescing/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-apply-nullish-coalescing [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-apply-nullish-coalescing [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-apply-nullish-coalescing.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-apply-nullish-coalescing"npm"

--- a/packages/plugin-apply-optional-chaining/README.md
+++ b/packages/plugin-apply-optional-chaining/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-apply-optional-chaining [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-apply-optional-chaining [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-apply-optional-chaining.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-apply-optional-chaining"npm"

--- a/packages/plugin-convert-apply-to-spread/README.md
+++ b/packages/plugin-convert-apply-to-spread/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-apply-to-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-apply-to-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-apply-to-spread.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-apply-to-spread "npm"

--- a/packages/plugin-convert-arguments-to-rest/README.md
+++ b/packages/plugin-convert-arguments-to-rest/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-arguments-to-rest [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-arguments-to-rest [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-arguments-to-rest.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-arguments-to-rest "npm"

--- a/packages/plugin-convert-binary-expression-to-boolean/README.md
+++ b/packages/plugin-convert-binary-expression-to-boolean/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-binary-expression-to-boolean [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-binary-expression-to-boolean [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-binary-expression-to-boolean.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-binary-expression-to-boolean"npm"

--- a/packages/plugin-convert-commonjs-to-esm/README.md
+++ b/packages/plugin-convert-commonjs-to-esm/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-commonjs-to-esm [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-commonjs-to-esm [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-commonjs-to-esm.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-commonjs-to-esm"npm"

--- a/packages/plugin-convert-equal-to-strict-equal/README.md
+++ b/packages/plugin-convert-equal-to-strict-equal/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-equal-to-strict-equal [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-equal-to-strict-equal [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-equal-to-strict-equal.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-equal-to-strict-equal "npm"

--- a/packages/plugin-convert-esm-to-commonjs/README.md
+++ b/packages/plugin-convert-esm-to-commonjs/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-esm-to-commonjs [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-esm-to-commonjs [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-esm-to-commonjs.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-esm-to-commonjs"npm"
 

--- a/packages/plugin-convert-generic-to-shorthand/README.md
+++ b/packages/plugin-convert-generic-to-shorthand/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-generic-to-shorthand [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-generic-to-shorthand [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-generic-to-shorthand.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-generic-to-shorthand "npm"

--- a/packages/plugin-convert-index-of-to-includes/README.md
+++ b/packages/plugin-convert-index-of-to-includes/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-index-of-to-includes [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-index-of-to-includes [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-index-of-to-includes.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-index-of-to-includes "npm"

--- a/packages/plugin-convert-math-pow/README.md
+++ b/packages/plugin-convert-math-pow/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-math-pow [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-math-pow [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-math-pow.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-math-pow "npm"

--- a/packages/plugin-convert-object-assign-to-merge-spread/README.md
+++ b/packages/plugin-convert-object-assign-to-merge-spread/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-object-assign-to-merge-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-object-assign-to-merge-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-object-assign-to-merge-spread.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-object-assign-to-merge-spread"npm"

--- a/packages/plugin-convert-spread-to-array-from/README.md
+++ b/packages/plugin-convert-spread-to-array-from/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-spread-to-array-from [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-spread-to-array-from [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-spread-to-array-from.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-spread-to-array-from"npm"

--- a/packages/plugin-convert-template-to-string/README.md
+++ b/packages/plugin-convert-template-to-string/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-template-to-string [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-template-to-string [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-template-to-string.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-template-to-string"npm"

--- a/packages/plugin-convert-throw/README.md
+++ b/packages/plugin-convert-throw/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-throw [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-throw [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-throw.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-throw "npm"

--- a/packages/plugin-convert-to-arrow-function/README.md
+++ b/packages/plugin-convert-to-arrow-function/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-to-arrow-function [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-to-arrow-function [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-to-arrow-function.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-to-arrow-function"npm"

--- a/packages/plugin-convert-top-level-return/README.md
+++ b/packages/plugin-convert-top-level-return/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-convert-top-level-return [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-convert-top-level-return [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-convert-top-level-return.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-convert-top-level-return"npm"

--- a/packages/plugin-extract-object-properties/README.md
+++ b/packages/plugin-extract-object-properties/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-extract-object-properties [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-extract-object-properties [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-extract-object-properties.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-extract-object-properties"npm"

--- a/packages/plugin-merge-duplicate-imports/README.md
+++ b/packages/plugin-merge-duplicate-imports/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-merge-duplicate-imports [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-merge-duplicate-imports [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-merge-duplicate-imports.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-merge-duplicate-imports "npm"

--- a/packages/plugin-merge-if-statements/README.md
+++ b/packages/plugin-merge-if-statements/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-merge-if-statements [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-merge-if-statements [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-merge-if-statements.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-merge-if-statements"npm"

--- a/packages/plugin-promises/README.md
+++ b/packages/plugin-promises/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-promises [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-promises [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-promises.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-promises"npm"

--- a/packages/plugin-react-hooks/README.md
+++ b/packages/plugin-react-hooks/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-react-hooks [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-react-hooks [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-react-hooks.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-react-hooks"npm"

--- a/packages/plugin-remove-boolean-from-logical-expressions/README.md
+++ b/packages/plugin-remove-boolean-from-logical-expressions/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-boolean-from-logical-expression [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-boolean-from-logical-expression [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-boolean-from-logical-expression.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-boolean-from-logical-expression"npm"

--- a/packages/plugin-remove-console/README.md
+++ b/packages/plugin-remove-console/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-console [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-console [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-console.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-console"npm"

--- a/packages/plugin-remove-constant-conditions/README.md
+++ b/packages/plugin-remove-constant-conditions/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-constant-conditions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-constant-conditions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-constant-conditions.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-constant-conditions"npm"

--- a/packages/plugin-remove-debugger/README.md
+++ b/packages/plugin-remove-debugger/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-debugger [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-debugger [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-debugger.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-debugger"npm"

--- a/packages/plugin-remove-double-negations/README.md
+++ b/packages/plugin-remove-double-negations/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-double-negations [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-double-negations [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-double-negations.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-double-negations"npm"

--- a/packages/plugin-remove-duplicate-interface-keys/README.md
+++ b/packages/plugin-remove-duplicate-interface-keys/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-duplicate-interface-keys [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-duplicate-interface-keys [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-duplicate-interface-keys.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-duplicate-interface-keys"npm"

--- a/packages/plugin-remove-duplicate-keys/README.md
+++ b/packages/plugin-remove-duplicate-keys/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-duplicate-keys [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-duplicate-keys [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-duplicate-keys.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-duplicate-keys"npm"

--- a/packages/plugin-remove-empty-pattern/README.md
+++ b/packages/plugin-remove-empty-pattern/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-empty-pattern [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-empty-pattern [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-empty-pattern.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-empty-pattern"npm"

--- a/packages/plugin-remove-nested-blocks/README.md
+++ b/packages/plugin-remove-nested-blocks/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-nested-blocks [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-nested-blocks [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-nested-blocks.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-nested-blocks"npm"

--- a/packages/plugin-remove-only/README.md
+++ b/packages/plugin-remove-only/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-only [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-only [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-only.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-only"npm"

--- a/packages/plugin-remove-process-exit/README.md
+++ b/packages/plugin-remove-process-exit/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-process-exit [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-process-exit [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-process-exit.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-process-exit"npm"

--- a/packages/plugin-remove-skip/README.md
+++ b/packages/plugin-remove-skip/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-skip [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-skip [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-skip.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-skip"npm"

--- a/packages/plugin-remove-unreachable-code/README.md
+++ b/packages/plugin-remove-unreachable-code/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-unreachable-code [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-unreachable-code [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-unreachable-code.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-unreachable-code"npm"

--- a/packages/plugin-remove-unreferenced-variables/README.md
+++ b/packages/plugin-remove-unreferenced-variables/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-unreferenced-variables [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-unreferenced-variables [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-unreferenced-variables.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-unreferenced-variables"npm"

--- a/packages/plugin-remove-unused-for-of-variables/README.md
+++ b/packages/plugin-remove-unused-for-of-variables/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-unused-for-of-variables [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-unused-for-of-variables [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-unused-for-of-variables.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-unused-for-of-variables"npm"

--- a/packages/plugin-remove-unused-private-fields/README.md
+++ b/packages/plugin-remove-unused-private-fields/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-unused-private-fields [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-unused-private-fields [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-unused-private-fields.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-unused-private-fields"npm"

--- a/packages/plugin-remove-useless-array-from/README.md
+++ b/packages/plugin-remove-useless-array-from/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-array-from [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-array-from [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-array-from.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-array-from"npm"

--- a/packages/plugin-remove-useless-async/README.md
+++ b/packages/plugin-remove-useless-async/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-async [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-async [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-async.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-async"npm"

--- a/packages/plugin-remove-useless-escape/README.md
+++ b/packages/plugin-remove-useless-escape/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-escape [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-escape [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-escape.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-escape"npm"

--- a/packages/plugin-remove-useless-functions/README.md
+++ b/packages/plugin-remove-useless-functions/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-functions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-functions [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-functions.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-functions "npm"

--- a/packages/plugin-remove-useless-spread/README.md
+++ b/packages/plugin-remove-useless-spread/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-spread [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-spread.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-spread"npm"

--- a/packages/plugin-remove-useless-templates/README.md
+++ b/packages/plugin-remove-useless-templates/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-templates [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-templates [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-templates.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-templates"npm"

--- a/packages/plugin-remove-useless-typeof/README.md
+++ b/packages/plugin-remove-useless-typeof/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-remove-useless-typeof [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-remove-useless-typeof [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-remove-useless-typeof.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-remove-useless-typeof"npm"

--- a/packages/plugin-reuse-duplicate-init/README.md
+++ b/packages/plugin-reuse-duplicate-init/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-reuse-duplicate-init [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-reuse-duplicate-init [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-reuse-duplicate-init.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-reuse-duplicate-init "npm"

--- a/packages/plugin-simplify-ternary/README.md
+++ b/packages/plugin-simplify-ternary/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-simplify-ternary [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-simplify-ternary [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-simplify-ternary.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-simplify-ternary "npm"

--- a/packages/plugin-split-nested-destructuring/README.md
+++ b/packages/plugin-split-nested-destructuring/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-split-nested-destructuring [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-split-nested-destructuring [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-split-nested-destructuring.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-split-nested-destructuring "npm"

--- a/packages/plugin-split-variable-declarations/README.md
+++ b/packages/plugin-split-variable-declarations/README.md
@@ -1,4 +1,4 @@
-# putout-plugin-split-variable-declarations [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
+# @putout/plugin-split-variable-declarations [![NPM version][NPMIMGURL]][NPMURL] [![Dependency Status][DependencyStatusIMGURL]][DependencyStatusURL]
 
 [NPMIMGURL]:                https://img.shields.io/npm/v/@putout/plugin-split-variable-declarations.svg?style=flat&longCache=true
 [NPMURL]:                   https://npmjs.org/package/@putout/plugin-split-variable-declarations"npm"


### PR DESCRIPTION
Went through each folder in the packages/ folder and changed the headers to reference @putout/plugin instead of putout-plugin.

Addresses issue [#26](https://github.com/coderaiser/putout/issues/26#issuecomment-708424409)