### PR TITLE
fix(41): putout dep

### DIFF
--- a/packages/eslint-plugin-putout/README.md
+++ b/packages/eslint-plugin-putout/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```
-$ npm i eslint eslint-plugin-putout -D
+$ npm i putout eslint eslint-plugin-putout -D
 ```
 
 **Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-putout` globally.

--- a/packages/eslint-plugin-putout/lib/keyword-spacing/index.js
+++ b/packages/eslint-plugin-putout/lib/keyword-spacing/index.js
@@ -3,7 +3,7 @@
 const {
     isTryStatement,
     isSwitchStatement,
-} = require('putout').types;
+} = require('../putout-wrapper')().types;
 
 const keywords = {
     IfStatement: 'if',

--- a/packages/eslint-plugin-putout/lib/putout-wrapper.js
+++ b/packages/eslint-plugin-putout/lib/putout-wrapper.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = () => {
+    try {
+        const putout = require('putout');
+        return putout;
+    } catch (e) {
+        throw e;
+    }
+};

--- a/packages/eslint-plugin-putout/lib/putout/index.js
+++ b/packages/eslint-plugin-putout/lib/putout/index.js
@@ -6,7 +6,7 @@ const {
     transform,
     print,
     parse,
-} = require('putout');
+} = require('../putout-wrapper')();
 
 const parseOptions = require('putout/lib/parse-options');
 


### PR DESCRIPTION
Based on #41 

1. [x] Add putout to the `npm i eslint eslint-plugin-putout` line of [the read me](https://github.com/coderaiser/putout/blob/master/packages/eslint-plugin-putout/README.md#installation)
1. [x] Add a try/catch around [a root `require('putout')`](https://github.com/coderaiser/putout/blob/b67449d0e9265769e0526d56d58774e4b3113d3e/packages/eslint-plugin-putout/lib/putout/index.js#L9) w/ a clear+friendly error message