### PR TITLE
Adding `npx` to usage examples to make execution easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ The main difference of `putout` is saving code transformation results directly i
 
 ## Installation
 
+To install `Putout` as a development dependency, run:
+
 ```
 npm i putout -D
 ```
+
+Or, for one-off usage, you can execute `Putout` directly with npm's package executor: `npx putout`.
+
+Make sure that you are running a recent (16.0<) version of Node.
 
 ## Usage
 
@@ -90,21 +96,22 @@ Options
 To find possible transform places:
 
 ```
-putout lib test
+npx putout lib test
 ```
 
 To apply transforms:
 
 ```
-putout lib test --fix
+npx putout lib test --fix
 ```
 
 ### Environment variables
 
-`Putout` supports next `environment variables`:
+`Putout` supports the following environment variables:
 
 - `PUTOUT_FILES` - files that should be processed by putout, divided by ",";
 
+Example:
 ```
 PUTOUT_FILES=lib,test putout --fix
 ```
@@ -619,7 +626,6 @@ interface A {
 ```
 
 </details>
-   
 
 <details><summary>remove useless <code><a href=https://www.typescriptlang.org/docs/handbook/2/mapped-types.html>mapped types</a></code>(for typescript)</summary>
 


### PR DESCRIPTION
The previous installation example assumed that you had your current directory's node_modules in your execution path, and so readers that tried out the "Installation & Usage" example would get a "Command not found".

This path annoyance is avoided by adding `npx` in front of the usage examples; now readers are able to follow the usage examples without being frustrated, and are also shown how to run Putout without saving it as a dependency.

I mention "Make sure that you are running a recent version of Node" since if you run Putout with `npm run` on version 14 of Node, you get an error from the top-level await in [/bin/putout.mjs](https://github.com/coderaiser/putout/blob/master/packages/putout/bin/putout.mjs).