### PR TITLE
feat: add more cases for `apply-filter-boolean` rule

### DIFF
--- a/packages/plugin-apply-filter-boolean/lib/apply-filter-boolean.js
+++ b/packages/plugin-apply-filter-boolean/lib/apply-filter-boolean.js
@@ -4,6 +4,10 @@ module.exports.report = () => 'Use Boolean constructor';
 
 module.exports.replace = () => ({
     '__a.filter(__b => __b)': '__a.filter(Boolean)',
+    '__a.filter(__b => Boolean(__b))': '__a.filter(Boolean)',
+    '__a.filter(__b => !!__b)': '__a.filter(Boolean)',
     '__a.find(__b => __b)': '__a.find(Boolean)',
+    '__a.find(__b => Boolean(__b))': '__a.find(Boolean)',
+    '__a.find(__b => !!__b)': '__a.find(Boolean)',
 });
 

--- a/packages/plugin-apply-filter-boolean/test/apply-filter-boolean.js
+++ b/packages/plugin-apply-filter-boolean/test/apply-filter-boolean.js
@@ -11,7 +11,7 @@ test('plugin-apply-filter-boolean: transform: report', (t) => {
     t.end();
 });
 
-test('plugin-apply-filter-boolean: transform: object', (t) => {
+test('plugin-apply-filter-boolean: transform: array', (t) => {
     t.transform('array');
     t.end();
 });

--- a/packages/plugin-apply-filter-boolean/test/fixture/array-fix.js
+++ b/packages/plugin-apply-filter-boolean/test/fixture/array-fix.js
@@ -1,1 +1,3 @@
-arra.filter(Boolean);
+array.filter(Boolean);
+array.filter(Boolean);
+array.filter(Boolean);

--- a/packages/plugin-apply-filter-boolean/test/fixture/array.js
+++ b/packages/plugin-apply-filter-boolean/test/fixture/array.js
@@ -1,1 +1,3 @@
-arra.filter((a) => a);
+array.filter((a) => a);
+array.filter((a) => Boolean(a));
+array.filter((a) => !!a);

--- a/packages/plugin-apply-filter-boolean/test/fixture/find-fix.js
+++ b/packages/plugin-apply-filter-boolean/test/fixture/find-fix.js
@@ -1,1 +1,3 @@
-arra.find(Boolean);
+array.find(Boolean);
+array.find(Boolean);
+array.find(Boolean);

--- a/packages/plugin-apply-filter-boolean/test/fixture/find.js
+++ b/packages/plugin-apply-filter-boolean/test/fixture/find.js
@@ -1,1 +1,3 @@
-arra.find((a) => a);
+array.find((a) => a);
+array.find((a) => Boolean(a));
+array.find((a) => !!a);


### PR DESCRIPTION
Hi @coderaiser, I think the cases like `a => Boolean(a)` and `a => !!a` also must be reported

Also, we can report not only for `find` method but also for `some`, `every`, `findIndex` methods?