### PR TITLE
fix(@putout/engine-loader) add `putout` to `peerDependencies` - Fixes #105

### DIFF
--- a/packages/engine-loader/package.json
+++ b/packages/engine-loader/package.json
@@ -37,6 +37,9 @@
     "putout-engine",
     "loader"
   ],
+  "peerDependencies": {
+    "putout": "*"
+  },
   "devDependencies": {
     "@babel/plugin-codemod-object-assign-to-object-spread": "^7.7.4",
     "@putout/formatter-progress": "*",


### PR DESCRIPTION
to make putout work when installed with `pnpm`

It's really just adding a peer dependency.

It fixes the problem for me - I'm using `putout` via `eslint-plugin-putout`.

After the change, `pnpm why putout` shows:
```
putout 26.16.0
├─┬ @putout/engine-loader 7.1.0
│ └── putout 26.16.0 peer
```

Let me know if it's all good - first time doing a GitHub PR.