### PR TITLE
fix(engine-*): Add missing peerDependencies

### DIFF
--- a/packages/engine-processor/package.json
+++ b/packages/engine-processor/package.json
@@ -47,6 +47,9 @@
     "putout": "*",
     "supertape": "^8.0.0"
   },
+  "peerDependencies": {
+    "putout": "*"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=16"

--- a/packages/engine-runner/package.json
+++ b/packages/engine-runner/package.json
@@ -57,6 +57,9 @@
     "putout": "*",
     "supertape": "^8.0.0"
   },
+  "peerDependencies": {
+    "putout": "*"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
`engine-processor` and `engine-runner` are missing `peerDependencies` on `putout`.

While it's not a massive problem, it does make life harder for package managers when trying to optimize package installation, see [Implicit Transitive Peer Dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

`yarn` currently reports both of these packages as missing peer dependencies:

```
➤ YN0002: │ @putout/engine-processor@npm:8.0.0 doesn't provide putout (p32a21), requested by @putout/engine-loader
➤ YN0002: │ @putout/engine-runner@npm:17.2.0 doesn't provide putout (p8a555), requested by @putout/operator-declare
```