### PR TITLE
feature: @putout/plugin-remove-nested-blocks: case when it is the only block

### DIFF
--- a/packages/plugin-remove-nested-blocks/lib/remove-nested-blocks.js
+++ b/packages/plugin-remove-nested-blocks/lib/remove-nested-blocks.js
@@ -49,7 +49,10 @@ module.exports.filter = (path) => {
     
     const is = !isIntersect(bindings, path.parentPath);
     
-    return is && (parentPath.isBlockStatement() || parentPath.isProgram());
+    if (!parentPath.isBlockStatement() && !parentPath.isProgram())
+        return false;
+    
+    return is || path.container.length === 1;
 };
 
 function isReturnWithoutArg(path) {

--- a/packages/plugin-remove-nested-blocks/test/fixture/intersect-multi.js
+++ b/packages/plugin-remove-nested-blocks/test/fixture/intersect-multi.js
@@ -1,0 +1,7 @@
+function fun1(f) {
+    let x1;
+    {
+        let x1 = f;
+        return x1;
+    }
+}

--- a/packages/plugin-remove-nested-blocks/test/fixture/intersect-single-fix.js
+++ b/packages/plugin-remove-nested-blocks/test/fixture/intersect-single-fix.js
@@ -1,0 +1,6 @@
+let x1;
+
+function fun1(f) {
+    let x1 = f;
+    return x1;
+}

--- a/packages/plugin-remove-nested-blocks/test/fixture/intersect-single.js
+++ b/packages/plugin-remove-nested-blocks/test/fixture/intersect-single.js
@@ -1,0 +1,7 @@
+let x1;
+function fun1(f) {
+    {
+        let x1 = f;
+        return x1;
+    }
+}

--- a/packages/plugin-remove-nested-blocks/test/remove-nested-blocks.js
+++ b/packages/plugin-remove-nested-blocks/test/remove-nested-blocks.js
@@ -61,3 +61,13 @@ test('plugin-remove-nested-blocks: no report: return', (t) => {
     t.noReport('return');
     t.end();
 });
+
+test('plugin-remove-nested-blocks: transform: intersect-single', (t) => {
+    t.transform('intersect-single');
+    t.end();
+});
+
+test('plugin-remove-nested-blocks: no report: intersect-multi', (t) => {
+    t.noReport('intersect-multi');
+    t.end();
+});


### PR DESCRIPTION
When a block is the only block in its container, this nested block can be removed safely:

```js
let x1;
function fun1(f) {
    {
        let x1 = f;
        return x1;
    }
}
```
