### PR TITLE
feature: @putout/plugin-remove-unreachable-code: backtracking parents and enhancements

### DIFF
--- a/packages/plugin-remove-unreachable-code/test/fixture/backtrack-func.js
+++ b/packages/plugin-remove-unreachable-code/test/fixture/backtrack-func.js
@@ -1,0 +1,9 @@
+let x3 = 1;
+function fun3(f) {
+  {
+    let x3 = f + 2;
+    return x3 * 2;
+  }
+  function m() {}
+}
+fun3(x3)

--- a/packages/plugin-remove-unreachable-code/test/fixture/backtrack-normal-fix.js
+++ b/packages/plugin-remove-unreachable-code/test/fixture/backtrack-normal-fix.js
@@ -1,0 +1,10 @@
+let x3 = 1;
+
+function fun3(f) {
+    {
+        let x3 = f + 2;
+        return x3 * 2;
+    }
+}
+
+fun3(x3);

--- a/packages/plugin-remove-unreachable-code/test/fixture/backtrack-normal.js
+++ b/packages/plugin-remove-unreachable-code/test/fixture/backtrack-normal.js
@@ -1,0 +1,11 @@
+let x3 = 1;
+
+function fun3(f) {
+    {
+        let x3 = f + 2;
+        return x3 * 2;
+    }
+    return 3;
+}
+
+fun3(x3);

--- a/packages/plugin-remove-unreachable-code/test/fixture/hoist-and-other-fix.js
+++ b/packages/plugin-remove-unreachable-code/test/fixture/hoist-and-other-fix.js
@@ -1,0 +1,4 @@
+function f() {
+    return x;
+    function m() {}
+}

--- a/packages/plugin-remove-unreachable-code/test/fixture/hoist-and-other.js
+++ b/packages/plugin-remove-unreachable-code/test/fixture/hoist-and-other.js
@@ -1,0 +1,5 @@
+function f() {
+    return x;
+    function m() {}
+    return 1;
+}

--- a/packages/plugin-remove-unreachable-code/test/remove-unreachable-code.js
+++ b/packages/plugin-remove-unreachable-code/test/remove-unreachable-code.js
@@ -33,3 +33,18 @@ test('plugin-remove-unreachable-code: no report: return-no-arg', (t) => {
     t.noReport('return-no-arg');
     t.end();
 });
+
+test('plugin-remove-unreachable-code: transform: hoist-and-other', (t) => {
+    t.transform('hoist-and-other');
+    t.end();
+});
+
+test('plugin-remove-unreachable-code: transform: backtrack-normal', (t) => {
+    t.transform('backtrack-normal');
+    t.end();
+});
+
+test('plugin-remove-unreachable-code: no report: backtrack-func', (t) => {
+    t.noReport('backtrack-func');
+    t.end();
+});


### PR DESCRIPTION
If there are function declarations, other expressions can be deleted safely.

```js
function fun2(f) {
  return 1;
  function m() {
  }
  return 2
}
```

As explained in #224, the next siblings in the parents can be deleted safely (except the function declarations):

```js
let x3 = 1;
function fun3(f) {
  {
    let x3 = f + 2;
    return x3 * 2;
  }
  return 3;
}
fun3(x3)
```