### PR TITLE
chore: ci: remove force flag from bun install

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Redrun
         run: bun install redrun -g --no-save
       - name: Install
-        run: bun i -f --no-save
+        run: bun i --no-save
       - name: Lint
         run: redrun fix:lint
       - name: Oxlint


### PR DESCRIPTION
Removing the '--force' flag from the 'bun install' command in the CI pipeline improves installation performance by allowing proper caching and incremental updates, rather than re-installing all dependencies from scratch in every run.

Technical Impact: Reduces CI job duration and network overhead.